### PR TITLE
Escape post.title in atom.xml

### DIFF
--- a/atom.xml
+++ b/atom.xml
@@ -16,7 +16,7 @@ layout: nil
  
  {% for post in site.posts %}
  <entry>
-   <title>{{ post.title }}</title>
+   <title>{{ post.title | xml_escape }}</title>
    <link href="http://blog.rubygems.org{{ post.url }}"/>
    <updated>{{ post.date | date_to_xmlschema }}</updated>
    <id>http://blog.rubygems.org{{ post.id }}</id>


### PR DESCRIPTION
If post.title were to contain one of `&`, `<`, or `>`, the XML would become invalid. `xml_escape` is a [Jekyll extension of Liquid](https://github.com/mojombo/jekyll/blob/master/lib/jekyll/filters.rb#L59-L72) to safely escape values.

Using straight Liquid, this could also be done with:

``` html
<title type="html">
    {{ post.title | escape
                  | replace:'&','&amp;'
                  | replace:'<','&lt;'
                  | replace:'>','&gt;' }}
</title>
```

(Note, `type=html` and then the [additional XML escaping](http://atomenabled.org/developers/syndication/#text).)
