### PR TITLE
Prevent overflow for unbreakable long string like SHA256

### DIFF
--- a/stylesheets/scss/_post.scss
+++ b/stylesheets/scss/_post.scss
@@ -5,6 +5,7 @@ article {
   max-width: $max-article-width;
   padding: 1em 2em;
   top: -200px;
+  word-wrap: break-word;
 
   .skip-to-archive, .skip-to-archive:visited {
     color: $red;


### PR DESCRIPTION
This pull request add a new css rule for `article` to prevent overflow for unbreakable long string like SHA256.

Before

![screenshot 2015-06-12 02 15 17](https://cloud.githubusercontent.com/assets/1000669/8114695/f3b1d2d8-10a8-11e5-9698-4fd619da54dc.png)

After

![screenshot 2015-06-12 02 16 23](https://cloud.githubusercontent.com/assets/1000669/8114710/0a92843e-10a9-11e5-97be-16f8a6124f72.png)

The post above is here: http://blog.rubygems.org/2015/06/08/2.4.8-released.html