### PR TITLE
SSL/TLSize all the things! (convert http:// to https:// where possible)

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -9,10 +9,10 @@
     {% else %}
     <title>{{ page.title }} | RubyGems.org</title>
     {% endif %}
-    <link rel="shortcut icon" href="http://rubygems.org/favicon.ico" type="image/x-icon">
+    <link rel="shortcut icon" href="https://rubygems.org/favicon.ico" type="image/x-icon">
     <link href="/atom.xml" rel="alternate" title="RSS" type="application/rss+xml" />
     <link href="/stylesheets/application.css" type="text/css" rel="stylesheet" />
-    <script type="text/javascript" src="//use.typekit.net/uqv7epg.js"></script>
+    <script type="text/javascript" src="https://use.typekit.net/uqv7epg.js"></script>
     <script type="text/javascript">try{Typekit.load();}catch(e){}</script>
     <script type="text/javascript" src="/javascripts/modernizr.js"></script>
     <script type="text/javascript" src="/javascripts/selectivizr.js"></script>
@@ -51,12 +51,12 @@
       <nav>
         <a href="https://rubygems.org/pages/about">About</a>
         <a href="http://help.rubygems.org">Help</a>
-        <a href="http://github.com/rubygems">Code</a>
-        <a href="http://twitter.com/rubygems">Status</a>
+        <a href="https://github.com/rubygems">Code</a>
+        <a href="https://twitter.com/rubygems">Status</a>
         <a href="http://guides.rubygems.org">Guides</a>
         <section class="credits">
           <span>Designed by</span>
-          <a href="http://thoughtbot.com" id="thoughtbot" title="Designed by Thoughtbot"><img alt="Thoughtbot" src="/images/thoughtbot.png?1253763695" /></a>
+          <a href="https://thoughtbot.com" id="thoughtbot" title="Designed by Thoughtbot"><img alt="Thoughtbot" src="/images/thoughtbot.png?1253763695" /></a>
           <span>Supported by</span>
           <a href="http://rubycentral.org" id="rubycentral" title="Supported by Ruby Central"><img alt="Rubycentral" src="/images/rubycentral.png?1258418593" /></a>
       </section>
@@ -70,7 +70,7 @@
         t.async = true;
         t.id    = 'gauges-tracker';
         t.setAttribute('data-site-id', '5147d6f8f5a1f502ad000189');
-        t.src = '//secure.gaug.es/track.js';
+        t.src = 'https://secure.gaug.es/track.js';
         var s = document.getElementsByTagName('script')[0];
         s.parentNode.insertBefore(t, s);
       })();

--- a/_posts/2011-08-31-shaving-the-yaml-yak.md
+++ b/_posts/2011-08-31-shaving-the-yaml-yak.md
@@ -131,7 +131,7 @@ You can see this problem manifest itself on the rubygems.org website if you look
 
 ![runtime deps screenshot](https://img.skitch.com/20110901-dcmqkfy9eyu69dp1xfbqyfe9wg.jpg)
 
-A simple [google search](http://www.google.com/search?hl=en&safe=off&q=defaultkey+site%3Arubygems.org&oq=defaultkey+site%3Arubygems.org&aq=f&aqi=&aql=&gs_sm=e&gs_upl=2623l8510l0l8586l57l29l0l12l0l3l348l2937l0.1.7.3l12l0) will show that this is not an uncommon problem.
+A simple [google search](https://www.google.com/search?hl=en&safe=off&q=defaultkey+site%3Arubygems.org&oq=defaultkey+site%3Arubygems.org&aq=f&aqi=&aql=&gs_sm=e&gs_upl=2623l8510l0l8586l57l29l0l12l0l3l348l2937l0.1.7.3l12l0) will show that this is not an uncommon problem.
 
 ### Command line errors
 

--- a/_posts/2013-03-05-2.0.1-released.md
+++ b/_posts/2013-03-05-2.0.1-released.md
@@ -31,6 +31,6 @@ _Bug fixes:_
 * Allow specification of mode for gem subdirectory creation.  Ruby bug #7713 by nobu
 * Fix tests when an 'a.rb' exists.  Ruby bug #7749 by nobu.
 
-[download]: http://rubygems.org/pages/download
-[upgrading]: http://docs.seattlerb.org/rubygems/UPGRADING_rdoc.html
+[download]: https://rubygems.org/pages/download
+[upgrading]: http://rubygems.rubyforge.org/rubygems-update/UPGRADING_rdoc.html
 [bugfixfix]: http://blog.rubygems.org/2013/03/06/2.0.2-released.html

--- a/_posts/2013-03-06-2.0.2-released.md
+++ b/_posts/2013-03-06-2.0.2-released.md
@@ -20,6 +20,6 @@ _Bug fixes:_
 * SSL Certificates are now installed properly.  Fixes #491 by hemanth.hm
 * Fixed HTTP to HTTPS upgrade for rubygems.org.
 
-[download]: http://rubygems.org/pages/download
-[upgrading]: http://docs.seattlerb.org/rubygems/UPGRADING_rdoc.html
+[download]: https://rubygems.org/pages/download
+[upgrading]: http://rubygems.rubyforge.org/rubygems-update/UPGRADING_rdoc.html
 

--- a/_posts/2013-03-11-2.0.3-released.md
+++ b/_posts/2013-03-11-2.0.3-released.md
@@ -24,5 +24,5 @@ _Bug fixes:_
 * Use the absolute path to the generated siteconf in case the extension changes directories to run extconf.rb (like memcached).  Fixes #498 by Chris Morris.
 * Fixed default gem key and cert locations.  Pull request #511 by Samuel Cochran.
 
-[download]: http://rubygems.org/pages/download
-[upgrading]: http://docs.seattlerb.org/rubygems/UPGRADING_rdoc.html
+[download]: https://rubygems.org/pages/download
+[upgrading]: http://rubygems.rubyforge.org/rubygems-update/UPGRADING_rdoc.html

--- a/_posts/2013-03-18-new-blog-design.md
+++ b/_posts/2013-03-18-new-blog-design.md
@@ -5,11 +5,11 @@ author: Nick Quaranto
 author_email: nick@quaran.to
 ---
 
-We have a brand new blog design courtesy of [thoughtbot](http://thoughtbot.com) and [Edwin Morris](http://github.com/ehmorris)!
+We have a brand new blog design courtesy of [thoughtbot](https://thoughtbot.com) and [Edwin Morris](https://github.com/ehmorris)!
 
 Some neat facts about this design:
 
-* The code for the blog is all [open source](http://github.com/rubygems/rubygems.github.com) and content is [Creative Commons](http://creativecommons.org/licenses/by-sa/3.0/us/) licensed.
+* The code for the blog is all [open source](https://github.com/rubygems/rubygems.github.com) and content is [Creative Commons](http://creativecommons.org/licenses/by-sa/3.0/us/) licensed.
 * It's now responsive, so it will look great on any device!
 * It's a great example for using [Bourbon](http://bourbon.io/), a simple set of SCSS mixins
 * All generated with [no Jekyll plugins!](http://quaran.to/blog/2013/01/09/use-jekyll-scss-coffeescript-without-plugins/)

--- a/_posts/2013-07-09-2.0.4-released.md
+++ b/_posts/2013-07-09-2.0.4-released.md
@@ -37,6 +37,6 @@ _Bug fixes:_
 * Cleaned up siteconf between extension build and extension install.  Pull request #587 by Dominic Cleal
 * Fix deprecation warnings when converting gemspecs to yaml.  Ruby commit r41148 by Yui Naruse
 
-[download]: http://rubygems.org/pages/download
-[upgrading]: http://docs.seattlerb.org/rubygems/UPGRADING_rdoc.html
+[download]: https://rubygems.org/pages/download
+[upgrading]: http://rubygems.rubyforge.org/rubygems-update/UPGRADING_rdoc.html
 

--- a/_posts/2013-07-11-2.0.5-released.md
+++ b/_posts/2013-07-11-2.0.5-released.md
@@ -19,6 +19,6 @@ _Bug fixes:_
 
 * Fixed building of extensions that run ruby in their makefiles.  Bug #589 by Zachary Salzbank.
 
-[download]: http://rubygems.org/pages/download
-[upgrading]: http://docs.seattlerb.org/rubygems/UPGRADING_rdoc.html
+[download]: https://rubygems.org/pages/download
+[upgrading]: http://rubygems.rubyforge.org/rubygems-update/UPGRADING_rdoc.html
 

--- a/_posts/2013-07-24-2.0.6-released.md
+++ b/_posts/2013-07-24-2.0.6-released.md
@@ -23,6 +23,6 @@ _Bug fixes:_
 * Fixed building extensions on ruby 1.9.3 under mingw.  Bug #594 by jonforums, Bug #599 by Chris Riesbeck
 * Restored default of remote search to `gem search`.
 
-[download]: http://rubygems.org/pages/download
-[upgrading]: http://docs.seattlerb.org/rubygems/UPGRADING_rdoc.html
+[download]: https://rubygems.org/pages/download
+[upgrading]: http://rubygems.rubyforge.org/rubygems-update/UPGRADING_rdoc.html
 

--- a/_posts/2013-07-25-2.1.0.rc.1-released.md
+++ b/_posts/2013-07-25-2.1.0.rc.1-released.md
@@ -61,5 +61,5 @@ _Bug fixes:_
 * rubygems_plugin.rb files are now only loaded from the latest installed gem.
 * Altered use of cryptography in the test suite to work on JRuby, but some tests still fail on JRuby.  Bug #606 by Hemant Kumar.
 
-[upgrading]: http://docs.seattlerb.org/rubygems/UPGRADING_rdoc.html
+[upgrading]: http://rubygems.rubyforge.org/rubygems-update/UPGRADING_rdoc.html
 

--- a/_posts/2013-08-15-2.0.7-released.md
+++ b/_posts/2013-08-15-2.0.7-released.md
@@ -22,6 +22,6 @@ _Bug fixes:_
 * Fixed various test failures due to platform differences or poor tests.  Patches by Yui Naruse and Koichi Sasada.
 * Fixed documentation for Kernel#require.
 
-[download]: http://rubygems.org/pages/download
-[upgrading]: http://docs.seattlerb.org/rubygems/UPGRADING_rdoc.html
+[download]: https://rubygems.org/pages/download
+[upgrading]: http://rubygems.rubyforge.org/rubygems-update/UPGRADING_rdoc.html
 

--- a/_posts/2013-08-26-2.1.0.rc.2-released.md
+++ b/_posts/2013-08-26-2.1.0.rc.2-released.md
@@ -64,5 +64,5 @@ _Bug fixes:_
 
 * rubygems_plugin.rb files are now only loaded from the latest installed gem.
 
-[upgrading]: http://docs.seattlerb.org/rubygems/UPGRADING_rdoc.html
+[upgrading]: http://rubygems.rubyforge.org/rubygems-update/UPGRADING_rdoc.html
 

--- a/_posts/2013-09-09-1.8.23.1-released.md
+++ b/_posts/2013-09-09-1.8.23.1-released.md
@@ -21,7 +21,7 @@ _Security fixes:_
 
 * RubyGems 2.0.7 and earlier are vulnerable to excessive CPU usage due to a backtracking in Gem::Version validation.  See [CVE-2013-4287][CVE-2013-4287] for full details including vulnerable APIs.  Fixed versions include 2.0.8, 1.8.26 and 1.8.23.1 (for Ruby 1.9.3).  Issue #626 by Damir Sharipov.
 
-[download]: http://rubygems.org/pages/download
-[upgrading]: http://docs.seattlerb.org/rubygems/UPGRADING_rdoc.html
+[download]: https://rubygems.org/pages/download
+[upgrading]: http://rubygems.rubyforge.org/rubygems-update/UPGRADING_rdoc.html
 [CVE-2013-4287]: /2013/09/09/CVE-2013-4287.html
 

--- a/_posts/2013-09-09-1.8.26-released.md
+++ b/_posts/2013-09-09-1.8.26-released.md
@@ -24,7 +24,7 @@ _Bug fixes:_
 
 * Fixed editing of a Makefile with 8-bit characters.  Fixes #181
 
-[download]: http://rubygems.org/pages/download
-[upgrading]: http://docs.seattlerb.org/rubygems/UPGRADING_rdoc.html
+[download]: https://rubygems.org/pages/download
+[upgrading]: http://rubygems.rubyforge.org/rubygems-update/UPGRADING_rdoc.html
 [CVE-2013-4287]: /2013/09/09/CVE-2013-4287.html
 

--- a/_posts/2013-09-09-2.0.8-released.md
+++ b/_posts/2013-09-09-2.0.8-released.md
@@ -25,7 +25,7 @@ _Bug fixes:_
 
 * Fixed Gem.clear_paths when Security is defined at top-level.  Pull request #625 by elarkin
 
-[download]: http://rubygems.org/pages/download
-[upgrading]: http://docs.seattlerb.org/rubygems/UPGRADING_rdoc.html
+[download]: https://rubygems.org/pages/download
+[upgrading]: http://rubygems.rubyforge.org/rubygems-update/UPGRADING_rdoc.html
 [CVE-2013-4287]: /2013/09/09/CVE-2013-4287.html
 

--- a/_posts/2013-09-09-2.1.0-released.md
+++ b/_posts/2013-09-09-2.1.0-released.md
@@ -66,7 +66,7 @@ _Bug fixes:_
 * Fixed Gem.clear_paths when Security is defined at top-level.  Pull request #625 by elarkin
 * Fixed credential creation for `gem push` when `--host` is not given.  Pull request #622 by Arthur Nogueira Neves
 
-[download]: http://rubygems.org/pages/download
-[upgrading]: http://docs.seattlerb.org/rubygems/UPGRADING_rdoc.html
+[download]: https://rubygems.org/pages/download
+[upgrading]: http://rubygems.rubyforge.org/rubygems-update/UPGRADING_rdoc.html
 [CVE-2013-4287]: /2013/09/09/CVE-2013-4287.html
 

--- a/_posts/2013-09-10-2.1.1-released.md
+++ b/_posts/2013-09-10-2.1.1-released.md
@@ -20,5 +20,5 @@ _Bug fixes:_
 
 * Only matching gems matching your local platform are considered for installation.  Issue #638 by José M. Prieto, issue #639 by sawanoboly.
 
-[download]: http://rubygems.org/pages/download
-[upgrading]: http://docs.seattlerb.org/rubygems/UPGRADING_rdoc.html
+[download]: https://rubygems.org/pages/download
+[upgrading]: http://rubygems.rubyforge.org/rubygems-update/UPGRADING_rdoc.html

--- a/_posts/2013-09-11-2.1.2-released.md
+++ b/_posts/2013-09-11-2.1.2-released.md
@@ -21,6 +21,6 @@ _Bug fixes:_
 * Gems with extensions are now installed correctly when the --install-dir option is used.  Issue #642 by Lin Jen-Shin.
 * Gem fetch now fetches the newest (not oldest) gem when --version is given. Issue #643 by Brian Shirai.
 
-[download]: http://rubygems.org/pages/download
-[upgrading]: http://docs.seattlerb.org/rubygems/UPGRADING_rdoc.html
+[download]: https://rubygems.org/pages/download
+[upgrading]: http://rubygems.rubyforge.org/rubygems-update/UPGRADING_rdoc.html
 

--- a/_posts/2013-09-12-2.1.3-released.md
+++ b/_posts/2013-09-12-2.1.3-released.md
@@ -19,6 +19,6 @@ _Bug fix:_
 
 * Gems with files entries starting with "./" no longer install 0 files.  Issue #644 by Darragh Curran, #645 by Brandon Turner, #646 by Alex Tambellini
 
-[download]: http://rubygems.org/pages/download
-[upgrading]: http://docs.seattlerb.org/rubygems/UPGRADING_rdoc.html
+[download]: https://rubygems.org/pages/download
+[upgrading]: http://rubygems.rubyforge.org/rubygems-update/UPGRADING_rdoc.html
 

--- a/_posts/2013-09-13-2.0.9-released.md
+++ b/_posts/2013-09-13-2.0.9-released.md
@@ -20,6 +20,6 @@ Bug fixes:
 * Gem fetch now fetches the newest (not oldest) gem when --version is given.  Issue #643 by Brian Shirai.
 * Fixed credential creation for `gem push` when `--host` is not given.  Pull request #622 by Arthur Nogueira Neves
 
-[download]: http://rubygems.org/pages/download
-[upgrading]: http://docs.seattlerb.org/rubygems/UPGRADING_rdoc.html
+[download]: https://rubygems.org/pages/download
+[upgrading]: http://rubygems.rubyforge.org/rubygems-update/UPGRADING_rdoc.html
 

--- a/_posts/2013-09-17-2.1.4-released.md
+++ b/_posts/2013-09-17-2.1.4-released.md
@@ -21,6 +21,6 @@ _Bug fixes:_
 * Fixed uninstalling gems installed in the home directory (as in `--user-install`).  Issue #653 by Lin Jen-Shin.
 
 
-[download]: http://rubygems.org/pages/download
-[upgrading]: http://docs.seattlerb.org/rubygems/UPGRADING_rdoc.html
+[download]: https://rubygems.org/pages/download
+[upgrading]: http://rubygems.rubyforge.org/rubygems-update/UPGRADING_rdoc.html
 

--- a/_posts/2013-09-24-1.8.23.2-released.md
+++ b/_posts/2013-09-24-1.8.23.2-released.md
@@ -19,6 +19,6 @@ _Security fixes:_
 
 * RubyGems 2.1.4 and earlier are vulnerable to excessive CPU usage due to a backtracking in Gem::Version validation.  See CVE-2013-4363 for full details including vulnerable APIs.  Fixed versions include 2.1.5, 2.0.10, 1.8.27 and 1.8.23.2 (for Ruby 1.9.3).
 
-[download]: http://rubygems.org/pages/download
-[upgrading]: http://docs.seattlerb.org/rubygems/UPGRADING_rdoc.html
+[download]: https://rubygems.org/pages/download
+[upgrading]: http://rubygems.rubyforge.org/rubygems-update/UPGRADING_rdoc.html
 

--- a/_posts/2013-09-24-1.8.27-released.md
+++ b/_posts/2013-09-24-1.8.27-released.md
@@ -19,6 +19,6 @@ _Security fixes:_
 
 * RubyGems 2.1.4 and earlier are vulnerable to excessive CPU usage due to a backtracking in Gem::Version validation.  See CVE-2013-4363 for full details including vulnerable APIs.  Fixed versions include 2.1.5, 2.0.10, 1.8.27 and 1.8.23.2 (for Ruby 1.9.3).
 
-[download]: http://rubygems.org/pages/download
-[upgrading]: http://docs.seattlerb.org/rubygems/UPGRADING_rdoc.html
+[download]: https://rubygems.org/pages/download
+[upgrading]: http://rubygems.rubyforge.org/rubygems-update/UPGRADING_rdoc.html
 

--- a/_posts/2013-09-24-2.0.10-released.md
+++ b/_posts/2013-09-24-2.0.10-released.md
@@ -19,6 +19,6 @@ _Security fixes:_
 
 * RubyGems 2.1.4 and earlier are vulnerable to excessive CPU usage due to a backtracking in Gem::Version validation.  See CVE-2013-4363 for full details including vulnerable APIs.  Fixed versions include 2.1.5, 2.0.10, 1.8.27 and 1.8.23.2 (for Ruby 1.9.3).
 
-[download]: http://rubygems.org/pages/download
-[upgrading]: http://docs.seattlerb.org/rubygems/UPGRADING_rdoc.html
+[download]: https://rubygems.org/pages/download
+[upgrading]: http://rubygems.rubyforge.org/rubygems-update/UPGRADING_rdoc.html
 

--- a/_posts/2013-09-24-2.1.5-released.md
+++ b/_posts/2013-09-24-2.1.5-released.md
@@ -19,6 +19,6 @@ _Security fixes:_
 
 * RubyGems 2.1.4 and earlier are vulnerable to excessive CPU usage due to a backtracking in Gem::Version validation.  See CVE-2013-4363 for full details including vulnerable APIs.  Fixed versions include 2.1.5, 2.0.10, 1.8.27 and 1.8.23.2 (for Ruby 1.9.3).
 
-[download]: http://rubygems.org/pages/download
-[upgrading]: http://docs.seattlerb.org/rubygems/UPGRADING_rdoc.html
+[download]: https://rubygems.org/pages/download
+[upgrading]: http://rubygems.rubyforge.org/rubygems-update/UPGRADING_rdoc.html
 

--- a/_posts/2013-10-08-1.8.28-released.md
+++ b/_posts/2013-10-08-1.8.28-released.md
@@ -22,6 +22,6 @@ _Bug fixes:_
 * Added test for missing certificates for https://s3.amazonaws.com or https://rubygems.org.  Pull request #673 by Hannes Georg.
 
 
-[download]: http://rubygems.org/pages/download
-[upgrading]: http://docs.seattlerb.org/rubygems/UPGRADING_rdoc.html
+[download]: https://rubygems.org/pages/download
+[upgrading]: http://rubygems.rubyforge.org/rubygems-update/UPGRADING_rdoc.html
 

--- a/_posts/2013-10-08-2.0.11-released.md
+++ b/_posts/2013-10-08-2.0.11-released.md
@@ -24,6 +24,6 @@ _Bug fixes:_
 * Required rbconfig in Gem::ConfigFile for Ruby 1.9.1 compatibility.  (Ruby 1.9.1 is no longer receiving security fixes, so please update to a newer version.)  Issue #676 by Michal Papis.  Issue wayneeseguin/rvm#2262 by Thomas Sänger.
 
 
-[download]: http://rubygems.org/pages/download
-[upgrading]: http://docs.seattlerb.org/rubygems/UPGRADING_rdoc.html
+[download]: https://rubygems.org/pages/download
+[upgrading]: http://rubygems.rubyforge.org/rubygems-update/UPGRADING_rdoc.html
 

--- a/_posts/2013-10-08-2.1.6-released.md
+++ b/_posts/2013-10-08-2.1.6-released.md
@@ -24,6 +24,6 @@ _Bug fixes:_
 * Required rbconfig in Gem::ConfigFile for Ruby 1.9.1 compatibility.  (Ruby 1.9.1 is no longer receiving security fixes, so please update to a newer version.)  Issue #676 by Michal Papis.  Issue wayneeseguin/rvm#2262 by Thomas Sänger.
 
 
-[download]: http://rubygems.org/pages/download
-[upgrading]: http://docs.seattlerb.org/rubygems/UPGRADING_rdoc.html
+[download]: https://rubygems.org/pages/download
+[upgrading]: http://rubygems.rubyforge.org/rubygems-update/UPGRADING_rdoc.html
 

--- a/_posts/2013-10-09-2.1.7-released.md
+++ b/_posts/2013-10-09-2.1.7-released.md
@@ -24,6 +24,6 @@ _Bug fixes:_
 * Expand unpack destination directory.  This fixes problems when File.realpath is missing and $GEM_HOME contains "..".  Issue #679 by Charles Nutter.
 
 
-[download]: http://rubygems.org/pages/download
-[upgrading]: http://docs.seattlerb.org/rubygems/UPGRADING_rdoc.html
+[download]: https://rubygems.org/pages/download
+[upgrading]: http://rubygems.rubyforge.org/rubygems-update/UPGRADING_rdoc.html
 

--- a/_posts/2013-10-10-2.1.8-released.md
+++ b/_posts/2013-10-10-2.1.8-released.md
@@ -22,6 +22,6 @@ _Bug fixes:_
 * The index generator no longer indexes default gems.  Issue #661 by Jeremy Hinegardner.
 
 
-[download]: http://rubygems.org/pages/download
-[upgrading]: http://docs.seattlerb.org/rubygems/UPGRADING_rdoc.html
+[download]: https://rubygems.org/pages/download
+[upgrading]: http://rubygems.rubyforge.org/rubygems-update/UPGRADING_rdoc.html
 

--- a/_posts/2013-10-14-2.0.12-released.md
+++ b/_posts/2013-10-14-2.0.12-released.md
@@ -20,6 +20,6 @@ _Bug fixes:_
 * Proxy usernames and passwords are now escaped properly.  Ruby Bug #8979 and patch by Masahiro Tomita, Issue #668 by Kouhei Sutou.
 
 
-[download]: http://rubygems.org/pages/download
-[upgrading]: http://docs.seattlerb.org/rubygems/UPGRADING_rdoc.html
+[download]: https://rubygems.org/pages/download
+[upgrading]: http://rubygems.rubyforge.org/rubygems-update/UPGRADING_rdoc.html
 

--- a/_posts/2013-10-14-2.1.9-released.md
+++ b/_posts/2013-10-14-2.1.9-released.md
@@ -21,6 +21,6 @@ _Bug fixes:_
 * Proxy usernames and passwords are now escaped properly.  Ruby Bug #8979 by Masahiro Tomita, Issue #668 by Kouhei Sutou.
 
 
-[download]: http://rubygems.org/pages/download
-[upgrading]: http://docs.seattlerb.org/rubygems/UPGRADING_rdoc.html
+[download]: https://rubygems.org/pages/download
+[upgrading]: http://rubygems.rubyforge.org/rubygems-update/UPGRADING_rdoc.html
 

--- a/_posts/2013-10-24-2.0.13-released.md
+++ b/_posts/2013-10-24-2.0.13-released.md
@@ -23,6 +23,6 @@ _Bug fixes:_
 * The gem server now uses user-provided directories.  Issue #696 by Marcelo Alvim.
 
 
-[download]: http://rubygems.org/pages/download
-[upgrading]: http://docs.seattlerb.org/rubygems/UPGRADING_rdoc.html
+[download]: https://rubygems.org/pages/download
+[upgrading]: http://rubygems.rubyforge.org/rubygems-update/UPGRADING_rdoc.html
 

--- a/_posts/2013-10-24-2.1.10-released.md
+++ b/_posts/2013-10-24-2.1.10-released.md
@@ -27,6 +27,6 @@ _Bug fixes:_
 * The `--ignore-dependencies` option for gem installation works again.  Issue #695
 
 
-[download]: http://rubygems.org/pages/download
-[upgrading]: http://docs.seattlerb.org/rubygems/UPGRADING_rdoc.html
+[download]: https://rubygems.org/pages/download
+[upgrading]: http://rubygems.rubyforge.org/rubygems-update/UPGRADING_rdoc.html
 

--- a/_posts/2013-11-12-2.0.14-released.md
+++ b/_posts/2013-11-12-2.0.14-released.md
@@ -23,6 +23,6 @@ _Bug fixes:_
 * The Gem::RemoteFetcher tests now choose the test server port more reliably. Pull Request #706 by akr.
 
 
-[download]: http://rubygems.org/pages/download
-[upgrading]: http://docs.seattlerb.org/rubygems/UPGRADING_rdoc.html
+[download]: https://rubygems.org/pages/download
+[upgrading]: http://rubygems.rubyforge.org/rubygems-update/UPGRADING_rdoc.html
 

--- a/_posts/2013-11-12-2.1.11-released.md
+++ b/_posts/2013-11-12-2.1.11-released.md
@@ -23,6 +23,6 @@ _Bug fixes:_
 * The Gem::RemoteFetcher tests now choose the test server port more reliably. Pull Request #706 by akr.
 
 
-[download]: http://rubygems.org/pages/download
-[upgrading]: http://docs.seattlerb.org/rubygems/UPGRADING_rdoc.html
+[download]: https://rubygems.org/pages/download
+[upgrading]: http://rubygems.rubyforge.org/rubygems-update/UPGRADING_rdoc.html
 

--- a/_posts/2013-11-23-1.8.29-released.md
+++ b/_posts/2013-11-23-1.8.29-released.md
@@ -20,7 +20,7 @@ _Bug fixes:_
 * Fixed installation when the LANG environment variable is empty.
 * Added DigiCert High Assurance EV Root CA to the default SSL certificates for cloudfront.
 
-[download]: http://rubygems.org/pages/download
-[upgrading]: http://docs.seattlerb.org/rubygems/UPGRADING_rdoc.html
+[download]: https://rubygems.org/pages/download
+[upgrading]: http://rubygems.rubyforge.org/rubygems-update/UPGRADING_rdoc.html
 
 

--- a/_posts/2013-12-20-2.2.0.rc.1-released.md
+++ b/_posts/2013-12-20-2.2.0.rc.1-released.md
@@ -66,6 +66,6 @@ _Bug fixes:_
 * Improved speed of `gem install --ignore-dependencies`.  Patch by Terence Lee.
 
 
-[download]: http://rubygems.org/pages/download
-[upgrading]: http://docs.seattlerb.org/rubygems/UPGRADING_rdoc.html
+[download]: https://rubygems.org/pages/download
+[upgrading]: http://rubygems.rubyforge.org/rubygems-update/UPGRADING_rdoc.html
 

--- a/_posts/2013-12-26-2.2.0-released.md
+++ b/_posts/2013-12-26-2.2.0-released.md
@@ -69,6 +69,6 @@ _Bug fixes:_
 * Improved speed of `gem install --ignore-dependencies`.  Patch by Terence Lee.
 
 
-[download]: http://rubygems.org/pages/download
-[upgrading]: http://docs.seattlerb.org/rubygems/UPGRADING_rdoc.html
+[download]: https://rubygems.org/pages/download
+[upgrading]: http://rubygems.rubyforge.org/rubygems-update/UPGRADING_rdoc.html
 

--- a/_posts/2014-01-06-2.2.1-released.md
+++ b/_posts/2014-01-06-2.2.1-released.md
@@ -29,6 +29,6 @@ _Bug fixes:_
 * Fixed specification file sorting for Ruby 1.8.7 compatibility.  Pull request #763 by James Mead
 
 
-[download]: http://rubygems.org/pages/download
-[upgrading]: http://docs.seattlerb.org/rubygems/UPGRADING_rdoc.html
+[download]: https://rubygems.org/pages/download
+[upgrading]: http://rubygems.rubyforge.org/rubygems-update/UPGRADING_rdoc.html
 

--- a/_posts/2014-02-05-2.2.2-released.md
+++ b/_posts/2014-02-05-2.2.2-released.md
@@ -31,6 +31,6 @@ _Bug fixes:_
 * Restored behavior of Gem::Version::new when subclassed.  Issue #805 by Sergio Rubio.
 
 
-[download]: http://rubygems.org/pages/download
-[upgrading]: http://docs.seattlerb.org/rubygems/UPGRADING_rdoc.html
+[download]: https://rubygems.org/pages/download
+[upgrading]: http://rubygems.rubyforge.org/rubygems-update/UPGRADING_rdoc.html
 

--- a/_posts/2014-06-10-2.3.0-released.md
+++ b/_posts/2014-06-10-2.3.0-released.md
@@ -82,6 +82,6 @@ _Bug fixes:_
 * Gem::BasicSpecification#require_paths respects default_ext_dir_for now.  Bug #852 by Vít Ondruch.
 
 
-[download]: http://rubygems.org/pages/download
-[upgrading]: http://docs.seattlerb.org/rubygems/UPGRADING_rdoc.html
+[download]: https://rubygems.org/pages/download
+[upgrading]: http://rubygems.rubyforge.org/rubygems-update/UPGRADING_rdoc.html
 

--- a/_posts/2014-07-16-2.4.0-released.md
+++ b/_posts/2014-07-16-2.4.0-released.md
@@ -58,6 +58,6 @@ SHA256 Checksums:
   a169d30852ebfa7972d7a359be4930871cd442798244ad7fae01d94aa6dbec33
 
 
-[download]: http://rubygems.org/pages/download
-[upgrading]: http://docs.seattlerb.org/rubygems/UPGRADING_rdoc.html
+[download]: https://rubygems.org/pages/download
+[upgrading]: http://rubygems.rubyforge.org/rubygems-update/UPGRADING_rdoc.html
 

--- a/_posts/2014-07-17-2.4.1-released.md
+++ b/_posts/2014-07-17-2.4.1-released.md
@@ -30,6 +30,6 @@ SHA256 Checksums:
   70bab9b876cd0c9087e9e03dea9c5c4afcc67770483a41fb02f6a4a6d484d759
 
 
-[download]: http://rubygems.org/pages/download
-[upgrading]: http://docs.seattlerb.org/rubygems/UPGRADING_rdoc.html
+[download]: https://rubygems.org/pages/download
+[upgrading]: http://rubygems.rubyforge.org/rubygems-update/UPGRADING_rdoc.html
 

--- a/_posts/2014-10-01-2.4.2-released.md
+++ b/_posts/2014-10-01-2.4.2-released.md
@@ -51,6 +51,6 @@ SHA256 Checksums:
   92b7b460a01208af3f59758816d9a314414f38e480c7870b18c75ea11d582360
 
 
-[download]: http://rubygems.org/pages/download
-[upgrading]: http://docs.seattlerb.org/rubygems/UPGRADING_rdoc.html
+[download]: https://rubygems.org/pages/download
+[upgrading]: http://rubygems.rubyforge.org/rubygems-update/UPGRADING_rdoc.html
 

--- a/_posts/2014-11-10-2.4.3-released.md
+++ b/_posts/2014-11-10-2.4.3-released.md
@@ -32,6 +32,6 @@ SHA256 Checksums:
   32fe3db16fa5746c622ed2c6e865854a3ec2c19c5fe566e325338dc84a14bf1d
 
 
-[download]: http://rubygems.org/pages/download
-[upgrading]: http://docs.seattlerb.org/rubygems/UPGRADING_rdoc.html
+[download]: https://rubygems.org/pages/download
+[upgrading]: http://rubygems.rubyforge.org/rubygems-update/UPGRADING_rdoc.html
 

--- a/_posts/2014-11-14-2.4.4-released.md
+++ b/_posts/2014-11-14-2.4.4-released.md
@@ -30,6 +30,6 @@ SHA256 Checksums:
   9ec22b1f44eaf27706803abfc93e9661b3decbe152e98b730cdc6bc1184f3597
 
 
-[download]: http://rubygems.org/pages/download
-[upgrading]: http://docs.seattlerb.org/rubygems/UPGRADING_rdoc.html
+[download]: https://rubygems.org/pages/download
+[upgrading]: http://rubygems.rubyforge.org/rubygems-update/UPGRADING_rdoc.html
 

--- a/_posts/2015-02-15-2.4.6-released.md
+++ b/_posts/2015-02-15-2.4.6-released.md
@@ -41,6 +41,6 @@ SHA256 Checksums:
   e11368dc8987461fd8858113fe3aa02f46723e521c5014c6b6293ed4317f2f98
 
 
-[download]: http://rubygems.org/pages/download
-[upgrading]: http://docs.seattlerb.org/rubygems/UPGRADING_rdoc.html
+[download]: https://rubygems.org/pages/download
+[upgrading]: http://rubygems.rubyforge.org/rubygems-update/UPGRADING_rdoc.html
 

--- a/_posts/2015-05-14-2.2.4-released.md
+++ b/_posts/2015-05-14-2.2.4-released.md
@@ -20,6 +20,6 @@ _Bug fixes:_
 * Backport: Limit API endpoint to original security domain for CVE-2015-3900. Fix by claudijd
 
 
-[download]: http://rubygems.org/pages/download
+[download]: https://rubygems.org/pages/download
 [upgrading]: http://rubygems.rubyforge.org/rubygems-update/UPGRADING_rdoc.html
 

--- a/_posts/2015-05-14-2.4.7-released.md
+++ b/_posts/2015-05-14-2.4.7-released.md
@@ -30,6 +30,6 @@ SHA256 Checksums:
   3ae1d969324b53be658c854e684e8f7fac6d2925affa791e8b62a29ef99f8917
 
 
-[download]: http://rubygems.org/pages/download
-[upgrading]: http://docs.seattlerb.org/rubygems/UPGRADING_rdoc.html
+[download]: https://rubygems.org/pages/download
+[upgrading]: http://rubygems.rubyforge.org/rubygems-update/UPGRADING_rdoc.html
 

--- a/_posts/2015-06-08-2.2.5-released.md
+++ b/_posts/2015-06-08-2.2.5-released.md
@@ -20,6 +20,6 @@ _Bug fixes:_
 * Tightened API endpoint checks for CVE-2015-3900
 
 
-[download]: http://rubygems.org/pages/download
+[download]: https://rubygems.org/pages/download
 [upgrading]: http://rubygems.rubyforge.org/rubygems-update/UPGRADING_rdoc.html
 

--- a/_posts/2015-06-08-2.4.8-released.md
+++ b/_posts/2015-06-08-2.4.8-released.md
@@ -30,6 +30,6 @@ SHA256 Checksums:
   dbed858db605923d9cc77080de1a5f1ce6ac3c68924877c78665e0d85d7b3e73
 
 
-[download]: http://rubygems.org/pages/download
-[upgrading]: http://docs.seattlerb.org/rubygems/UPGRADING_rdoc.html
+[download]: https://rubygems.org/pages/download
+[upgrading]: http://rubygems.rubyforge.org/rubygems-update/UPGRADING_rdoc.html
 


### PR DESCRIPTION
I know the blog uses GitHub Pages and isn't accessible over https:// (except for https://rubygems.github.io), but it would be good to at least have the download links and other things that could use https:// to actually use https://.

I also standardized on one UPGRADING URL since there were two of them being used (sadly neither support https://).